### PR TITLE
Add Railway git SHA fallback

### DIFF
--- a/config/initializers/git_sha.rb
+++ b/config/initializers/git_sha.rb
@@ -8,6 +8,9 @@ def fetch_git_sha
   # This is for Heroku. Ensure heroku labs:enable runtime-dyno-metadata is turned on.
   elsif ENV.fetch('HEROKU_SLUG_COMMIT', nil).present?
     ENV.fetch('HEROKU_SLUG_COMMIT', nil)
+  # Railway sets this environment variable with the commit SHA
+  elsif ENV.fetch('RAILWAY_GIT_COMMIT_SHA', nil).present?
+    ENV.fetch('RAILWAY_GIT_COMMIT_SHA', nil)
   else
     'unknown'
   end


### PR DESCRIPTION
## Summary
- check RAILWAY_GIT_COMMIT_SHA for the git hash in `git_sha.rb`

## Testing
- `bundle exec rubocop config/initializers/git_sha.rb`
- `pnpm eslint`
- `pnpm test` *(fails: not implemented errors)*
- `bundle exec rspec spec/models/account_spec.rb` *(fails: PG::ConnectionBad)*

------
https://chatgpt.com/codex/tasks/task_e_68565441d5cc8325b8ac8fa2fbd0a2b6